### PR TITLE
Add Merge and MergeNode filter effects

### DIFF
--- a/src/Graphics/SvgTree/Types.hs
+++ b/src/Graphics/SvgTree/Types.hs
@@ -86,6 +86,15 @@ module Graphics.SvgTree.Types
     , offsetDX
     , offsetDY
 
+    , MergeNode (..)
+    , mergeNodeDrawAttributes
+    , mergeNodeIn
+
+    , Merge (..)
+    , mergeDrawAttributes
+    , mergeFilterAttributes
+    , mergeChildren
+
     , ColorMatrixType(..)
     , colorMatrixDrawAttributes
     , colorMatrixFilterAttr

--- a/src/Graphics/SvgTree/Types/Hashable.hs
+++ b/src/Graphics/SvgTree/Types/Hashable.hs
@@ -72,6 +72,9 @@ deriving instance Hashable Tile
 
 deriving instance Hashable Offset
 
+deriving instance Hashable Merge
+deriving instance Hashable MergeNode
+
 deriving instance Hashable ColorMatrix
 
 deriving instance Hashable FilterSource

--- a/src/Graphics/SvgTree/Types/Instances.hs
+++ b/src/Graphics/SvgTree/Types/Instances.hs
@@ -85,6 +85,12 @@ instance HasDrawAttributes Tile where
 instance HasDrawAttributes Offset where
   drawAttributes = offsetDrawAttributes
 
+instance HasDrawAttributes Merge where
+  drawAttributes = mergeDrawAttributes
+
+instance HasDrawAttributes MergeNode where
+  drawAttributes = mergeNodeDrawAttributes
+
 instance HasDrawAttributes ColorMatrix where
   drawAttributes = colorMatrixDrawAttributes
 
@@ -131,6 +137,9 @@ instance HasFilterAttributes Turbulence where
 instance HasFilterAttributes DisplacementMap where
   filterAttributes = displacementMapFilterAttr
 
+instance HasFilterAttributes Merge where
+  filterAttributes = mergeFilterAttributes
+
 instance HasFilterAttributes FilterElement where
   filterAttributes = lens getter setter
     where
@@ -150,8 +159,8 @@ instance HasFilterAttributes FilterElement where
         FEFuncR -> defaultSvg
         FEGaussianBlur g -> g ^. filterAttributes
         FEImage -> defaultSvg
-        FEMerge -> defaultSvg
-        FEMergeNode -> defaultSvg
+        FEMergeNode _ -> defaultSvg --MergeNode has no filterAttributes!
+        FEMerge m -> m ^. filterAttributes
         FEMorphology -> defaultSvg
         FEOffset o -> o ^. filterAttributes
         FESpecularLighting -> defaultSvg
@@ -174,8 +183,8 @@ instance HasFilterAttributes FilterElement where
         FEFuncR -> fe
         FEGaussianBlur g -> FEGaussianBlur $ g & filterAttributes .~ attr
         FEImage -> fe
-        FEMerge -> fe
-        FEMergeNode -> fe
+        FEMerge m -> FEMerge $ m & filterAttributes .~ attr
+        FEMergeNode _ -> fe --MergeNode has no filterAttributes!
         FEMorphology -> fe
         FEOffset o -> FEOffset $ o & filterAttributes .~ attr
         FESpecularLighting -> fe

--- a/src/Graphics/SvgTree/Types/Internal.hs
+++ b/src/Graphics/SvgTree/Types/Internal.hs
@@ -89,6 +89,15 @@ module Graphics.SvgTree.Types.Internal
     offsetDX,
     offsetDY,
 
+    Merge (..),
+    mergeDrawAttributes,
+    mergeFilterAttributes,
+    mergeChildren,
+
+    MergeNode (..),
+    mergeNodeDrawAttributes,
+    mergeNodeIn,
+
     ColorMatrixType (..),
     colorMatrixDrawAttributes,
     colorMatrixFilterAttr,
@@ -1146,10 +1155,10 @@ data FilterElement
   | FEFuncR
   | FEGaussianBlur GaussianBlur -- SVG Basic --DONE
   | FEImage                     -- SVG Basic
-  | FEMerge                     -- SVG Basic
-  | FEMergeNode
+  | FEMerge Merge               -- SVG Basic --DONE
+  | FEMergeNode MergeNode       -- SVG Basic --DONE
   | FEMorphology
-  | FEOffset Offset             -- SVG Basic
+  | FEOffset Offset             -- SVG Basic --DONE
   | FESpecularLighting
   | FETile Tile                 -- SVG Basic --DONE
   | FETurbulence Turbulence
@@ -1297,6 +1306,35 @@ instance WithDefaultSvg Tile where
     { _tileDrawAttributes = defaultSvg,
       _tileFilterAttr = defaultSvg,
       _tileIn = Last Nothing
+    }
+
+data Merge = Merge
+  { _mergeDrawAttributes :: !DrawAttributes,
+    _mergeFilterAttributes :: !FilterAttributes,
+    _mergeChildren :: ![FilterElement]
+  }
+  deriving (Eq, Show, Generic)
+
+instance WithDefaultSvg Merge where
+  defaultSvg =
+    Merge
+    { _mergeDrawAttributes = defaultSvg,
+      _mergeFilterAttributes = defaultSvg,
+      _mergeChildren = []
+    }
+
+data MergeNode = MergeNode
+  { _mergeNodeDrawAttributes :: !DrawAttributes,
+    --Does not have filter attributes!
+    _mergeNodeIn :: !(Last FilterSource)
+  }
+  deriving (Eq, Show, Generic)
+
+instance WithDefaultSvg MergeNode where
+  defaultSvg =
+    MergeNode
+    { _mergeNodeDrawAttributes = defaultSvg,
+      _mergeNodeIn = Last Nothing
     }
 
 data ColorMatrixType
@@ -1882,6 +1920,8 @@ makeLenses ''Composite
 makeLenses ''GaussianBlur
 makeLenses ''Turbulence
 makeLenses ''DisplacementMap
+makeLenses ''Merge
+makeLenses ''MergeNode
 makeLenses ''Group
 
 makeClassy ''FilterAttributes


### PR DESCRIPTION
MergeNode has no Filter Attributes, which potentially breaks the FilterElement [HasFilterAttributes instance](https://github.com/joseedil/reanimate-svg/blob/d3998a7b62275b292aca42d44f8b16eadd0f9cab/src/Graphics/SvgTree/Types/Instances.hs#L143), but seems to be working correctly.

The [unparseFE](https://github.com/joseedil/reanimate-svg/blob/d3998a7b62275b292aca42d44f8b16eadd0f9cab/src/Graphics/SvgTree/XmlParser.hs#L1314) function has a potential bug: it allows [feMergeNode](https://developer.mozilla.org/en-US/docs/Web/SVG/Element/feMergeNode) elements to appear outside of [feMerge](https://developer.mozilla.org/en-US/docs/Web/SVG/Element/feMerge) elements.