### PR TITLE
Make number of decimal places for float serialisation configurable

### DIFF
--- a/src/Graphics/SvgTree.hs
+++ b/src/Graphics/SvgTree.hs
@@ -55,9 +55,9 @@ parseSvg inp =
     Just xml -> unparse xml
 
 -- | Save a svg Document on a file on disk.
-saveXmlFile :: FilePath -> Document -> IO ()
-saveXmlFile filePath =
-  writeFile filePath . ppcTopElement prettyConfigPP . xmlOfDocument
+saveXmlFile :: Int -> FilePath -> Document -> IO ()
+saveXmlFile precision filePath =
+  writeFile filePath . ppcTopElement prettyConfigPP . xmlOfDocument precision
 
 cssDeclApplyer ::
   DrawAttributes ->

--- a/src/Graphics/SvgTree/CssTypes.hs
+++ b/src/Graphics/SvgTree/CssTypes.hs
@@ -210,20 +210,23 @@ mapNumber f nu = case nu of
 
 -- | Encode the number to string which can be used in a
 -- CSS or a svg attributes.
-serializeNumber :: Number -> String
-serializeNumber n = case n of
-    Num c     -> ppD c
-    Px c      -> printf "%spx" (ppD c)
-    Em cc     -> printf "%sem" (ppD cc)
+serializeNumber :: Int -> Number -> String
+serializeNumber precision n = case n of
+    Num c     -> ppD precision c
+    Px c      -> printf "%spx" (ppD precision c)
+    Em cc     -> printf "%sem" (ppD precision cc)
     Percent p -> printf "%d%%" (floor $ 100 * p :: Int)
-    Pc p      -> printf "%spc" (ppD p)
-    Mm m      -> printf "%smm" (ppD m)
-    Cm c      -> printf "%scm" (ppD c)
-    Point p   -> printf "%spt" (ppD p)
-    Inches i  -> printf "%sin" (ppD i)
+    Pc p      -> printf "%spc" (ppD precision p)
+    Mm m      -> printf "%smm" (ppD precision m)
+    Cm c      -> printf "%scm" (ppD precision c)
+    Point p   -> printf "%spt" (ppD precision p)
+    Inches i  -> printf "%sin" (ppD precision i)
+
+hardcodedPrecision :: Int
+hardcodedPrecision = 6
 
 instance TextBuildable Number where
-   tserialize = TB.fromText . T.pack . serializeNumber
+   tserialize = TB.fromText . T.pack . serializeNumber hardcodedPrecision
 
 -- | Value of a CSS property.
 data CssElement

--- a/src/Graphics/SvgTree/Misc.hs
+++ b/src/Graphics/SvgTree/Misc.hs
@@ -11,15 +11,12 @@ import           Data.Double.Conversion.Text
 import qualified Data.Text                   as T
 #endif
 
-precision :: Int
-precision = 6
-
-ppD :: Double -> String
+ppD :: Int -> Double -> String
 #if defined(ASTERIUS) || defined(ghcjs_HOST_OS)
-ppD v = showFFloat (Just precision) v ""
+ppD precision v = showFFloat (Just precision) v ""
 #else
-ppD = T.unpack . T.dropWhileEnd (== '.') . T.dropWhileEnd (== '0') . toFixed precision
+ppD precision = T.unpack . T.dropWhileEnd (== '.') . T.dropWhileEnd (== '0') . toFixed precision
 #endif
 
-ppF :: Float -> String
-ppF = ppD . realToFrac
+ppF :: Int -> Float -> String
+ppF precision = ppD precision . realToFrac

--- a/src/Graphics/SvgTree/PathParser.hs
+++ b/src/Graphics/SvgTree/PathParser.hs
@@ -48,8 +48,12 @@ viewBoxParser = (,,,)
   where
     iParse = num <* skipSpace
 
-serializeViewBox :: (Double, Double, Double, Double) -> String
-serializeViewBox (a, b, c, d) = printf "%s %s %s %s" (ppD a) (ppD b) (ppD c) (ppD d)
+serializeViewBox :: Int -> (Double, Double, Double, Double) -> String
+serializeViewBox precision (a, b, c, d) = printf "%s %s %s %s"
+  (ppD precision a)
+  (ppD precision b)
+  (ppD precision c)
+  (ppD precision d)
 
 commaWsp :: Parser ()
 commaWsp = skipSpace *> option () (string "," $> ()) <* skipSpace
@@ -105,51 +109,51 @@ command =  (MoveTo OriginAbsolute <$ string "M" <*> pointList)
 unwordsS :: [ShowS] -> ShowS
 unwordsS = foldr (.) id . intersperse (showChar ' ')
 
-serializePoint :: RPoint -> ShowS
-serializePoint (V2 x y) = showString (ppD x) . showChar ',' . showString (ppD y)
+serializePoint :: Int -> RPoint -> ShowS
+serializePoint precision (V2 x y) = showString (ppD precision x) . showChar ',' . showString (ppD precision y)
 
-serializePoints :: [RPoint] -> ShowS
-serializePoints = unwordsS . map serializePoint
+serializePoints :: Int -> [RPoint] -> ShowS
+serializePoints precision = unwordsS . map (serializePoint precision)
 
-serializeCoords :: [Coord] -> ShowS
-serializeCoords = unwordsS . fmap (showString . ppD)
+serializeCoords :: Int -> [Coord] -> ShowS
+serializeCoords precision = unwordsS . fmap (showString . ppD precision)
 
-serializePointPair :: (RPoint, RPoint) -> ShowS
-serializePointPair (a, b) = serializePoint a . showChar ' ' . serializePoint b
+serializePointPair :: Int -> (RPoint, RPoint) -> ShowS
+serializePointPair precision (a, b) = serializePoint precision a . showChar ' ' . serializePoint precision b
 
-serializePointPairs :: [(RPoint, RPoint)] -> ShowS
-serializePointPairs = unwordsS . fmap serializePointPair
+serializePointPairs :: Int -> [(RPoint, RPoint)] -> ShowS
+serializePointPairs precision = unwordsS . fmap (serializePointPair precision)
 
-serializePointTriplet :: (RPoint, RPoint, RPoint) -> ShowS
-serializePointTriplet (a, b, c) =
-    serializePoint a . showChar ' ' . serializePoint b . showChar ' ' . serializePoint c
+serializePointTriplet :: Int -> (RPoint, RPoint, RPoint) -> ShowS
+serializePointTriplet precision (a, b, c) =
+    serializePoint precision a . showChar ' ' . serializePoint precision b . showChar ' ' . serializePoint precision c
 
-serializePointTriplets :: [(RPoint, RPoint, RPoint)] -> ShowS
-serializePointTriplets = unwordsS . fmap serializePointTriplet
+serializePointTriplets :: Int -> [(RPoint, RPoint, RPoint)] -> ShowS
+serializePointTriplets precision = unwordsS . fmap (serializePointTriplet precision)
 
-serializeCommands :: [PathCommand] -> ShowS
-serializeCommands = unwordsS . fmap serializeCommand
+serializeCommands :: Int -> [PathCommand] -> ShowS
+serializeCommands precision = unwordsS . fmap (serializeCommand precision)
 
-serializeCommand :: PathCommand -> ShowS
-serializeCommand p = case p of
-  MoveTo OriginAbsolute points -> showChar 'M' . serializePoints points
-  MoveTo OriginRelative points -> showChar 'm' . serializePoints points
-  LineTo OriginAbsolute points -> showChar 'L' . serializePoints points
-  LineTo OriginRelative points -> showChar 'l' . serializePoints points
+serializeCommand :: Int -> PathCommand -> ShowS
+serializeCommand precision p = case p of
+  MoveTo OriginAbsolute points -> showChar 'M' . serializePoints precision points
+  MoveTo OriginRelative points -> showChar 'm' . serializePoints precision points
+  LineTo OriginAbsolute points -> showChar 'L' . serializePoints precision points
+  LineTo OriginRelative points -> showChar 'l' . serializePoints precision points
 
-  HorizontalTo OriginRelative coords -> showChar 'h' . serializeCoords coords
-  HorizontalTo OriginAbsolute coords -> showChar 'H' . serializeCoords coords
-  VerticalTo OriginAbsolute coords   -> showChar 'V' . serializeCoords coords
-  VerticalTo OriginRelative coords   -> showChar 'v' . serializeCoords coords
+  HorizontalTo OriginRelative coords -> showChar 'h' . serializeCoords precision coords
+  HorizontalTo OriginAbsolute coords -> showChar 'H' . serializeCoords precision coords
+  VerticalTo OriginAbsolute coords   -> showChar 'V' . serializeCoords precision coords
+  VerticalTo OriginRelative coords   -> showChar 'v' . serializeCoords precision coords
 
-  CurveTo OriginAbsolute triplets -> showChar 'C' . serializePointTriplets triplets
-  CurveTo OriginRelative triplets -> showChar 'c' . serializePointTriplets triplets
-  SmoothCurveTo OriginAbsolute pointPairs -> showChar 'S' . serializePointPairs pointPairs
-  SmoothCurveTo OriginRelative pointPairs -> showChar 's' . serializePointPairs pointPairs
-  QuadraticBezier OriginAbsolute pointPairs -> showChar 'Q' . serializePointPairs pointPairs
-  QuadraticBezier OriginRelative pointPairs -> showChar 'q' . serializePointPairs pointPairs
-  SmoothQuadraticBezierCurveTo OriginAbsolute points -> showChar 'T' . serializePoints points
-  SmoothQuadraticBezierCurveTo OriginRelative points -> showChar 't' . serializePoints points
+  CurveTo OriginAbsolute triplets -> showChar 'C' . serializePointTriplets precision triplets
+  CurveTo OriginRelative triplets -> showChar 'c' . serializePointTriplets precision triplets
+  SmoothCurveTo OriginAbsolute pointPairs -> showChar 'S' . serializePointPairs precision pointPairs
+  SmoothCurveTo OriginRelative pointPairs -> showChar 's' . serializePointPairs precision pointPairs
+  QuadraticBezier OriginAbsolute pointPairs -> showChar 'Q' . serializePointPairs precision pointPairs
+  QuadraticBezier OriginRelative pointPairs -> showChar 'q' . serializePointPairs precision pointPairs
+  SmoothQuadraticBezierCurveTo OriginAbsolute points -> showChar 'T' . serializePoints precision points
+  SmoothQuadraticBezierCurveTo OriginRelative points -> showChar 't' . serializePoints precision points
   EllipticalArc OriginAbsolute args -> showChar 'A' . serializeArgs args
   EllipticalArc OriginRelative args -> showChar 'a' . serializeArgs args
   EndPath -> showChar 'Z'
@@ -157,7 +161,13 @@ serializeCommand p = case p of
     serializeArg (a, b, c, d, e, V2 x y) =
         showString $
         printf "%s %s %s %d %d %s,%s"
-          (ppD a) (ppD b) (ppD c) (fromEnum d) (fromEnum e) (ppD x) (ppD y)
+          (ppD precision a)
+          (ppD precision b)
+          (ppD precision c)
+          (fromEnum d)
+          (fromEnum e)
+          (ppD precision x)
+          (ppD precision y)
     serializeArgs = unwordsS . fmap serializeArg
 
 
@@ -248,15 +258,15 @@ gradientCommand =
                  <*> (point <* commaWsp)
                  <*> mayPoint
 
-serializeGradientCommand :: GradientPathCommand -> ShowS
-serializeGradientCommand p = case p of
+serializeGradientCommand :: Int -> GradientPathCommand -> ShowS
+serializeGradientCommand precision p = case p of
   GLine OriginAbsolute points -> showChar 'L' . smp points
   GLine OriginRelative points -> showChar 'l' . smp points
   GClose                      -> showChar 'Z'
 
-  GCurve OriginAbsolute a b c -> showChar 'C' . sp a . sp b . smp c
-  GCurve OriginRelative a b c -> showChar 'c' . sp a . sp b . smp c
+  GCurve OriginAbsolute a b c -> showChar 'C' . sp precision a . sp precision b . smp c
+  GCurve OriginRelative a b c -> showChar 'c' . sp precision a . sp precision b . smp c
   where
     sp = serializePoint
     smp Nothing   = id
-    smp (Just pp) = serializePoint pp
+    smp (Just pp) = serializePoint precision pp

--- a/src/Graphics/SvgTree/Printer.hs
+++ b/src/Graphics/SvgTree/Printer.hs
@@ -10,9 +10,9 @@ import Graphics.SvgTree.Types hiding (Element)
 import Graphics.SvgTree.XmlParser
 import Text.XML.Light hiding (showAttr)
 
-ppDocument :: Document -> String
-ppDocument doc =
-  ppElementS_ (_documentElements doc) (xmlOfDocument doc) ""
+ppDocument :: Int -> Document -> String
+ppDocument precision doc =
+  ppElementS_ (_documentElements doc) (xmlOfDocument precision doc) ""
 
 ppTree :: Tree -> String
 ppTree t = ppTreeS t ""

--- a/src/Graphics/SvgTree/Types/Internal.hs
+++ b/src/Graphics/SvgTree/Types/Internal.hs
@@ -549,36 +549,36 @@ data Transformation
 
 -- | Convert the Transformation to a string which can be
 -- directly used in a svg attributes.
-serializeTransformation :: Transformation -> String
-serializeTransformation t = case t of
+serializeTransformation :: Int -> Transformation -> String
+serializeTransformation precision t = case t of
   TransformUnknown -> ""
   TransformMatrix a b c d e f ->
     printf
       "matrix(%s, %s, %s, %s, %s, %s)"
-      (ppD a)
-      (ppD b)
-      (ppD c)
-      (ppD d)
-      (ppD e)
-      (ppD f)
-  Translate x y -> printf "translate(%s, %s)" (ppD x) (ppD y)
-  Scale x Nothing -> printf "scale(%s)" (ppD x)
-  Scale x (Just y) -> printf "scale(%s, %s)" (ppD x) (ppD y)
-  Rotate angle Nothing -> printf "rotate(%s)" (ppD angle)
+      (ppD precision a)
+      (ppD precision b)
+      (ppD precision c)
+      (ppD precision d)
+      (ppD precision e)
+      (ppD precision f)
+  Translate x y -> printf "translate(%s, %s)" (ppD precision x) (ppD precision y)
+  Scale x Nothing -> printf "scale(%s)" (ppD precision x)
+  Scale x (Just y) -> printf "scale(%s, %s)" (ppD precision x) (ppD precision y)
+  Rotate angle Nothing -> printf "rotate(%s)" (ppD precision angle)
   Rotate angle (Just (x, y)) ->
     printf
       "rotate(%s, %s, %s)"
-      (ppD angle)
-      (ppD x)
-      (ppD y)
-  SkewX x -> printf "skewX(%s)" (ppD x)
-  SkewY y -> printf "skewY(%s)" (ppD y)
+      (ppD precision angle)
+      (ppD precision x)
+      (ppD precision y)
+  SkewX x -> printf "skewX(%s)" (ppD precision x)
+  SkewY y -> printf "skewY(%s)" (ppD precision y)
 
 -- | Transform a list of transformations to a string for svg
 -- `transform` attributes.
-serializeTransformations :: [Transformation] -> String
-serializeTransformations =
-  unwords . fmap serializeTransformation
+serializeTransformations :: Int -> [Transformation] -> String
+serializeTransformations precision =
+  unwords . fmap (serializeTransformation precision)
 
 -- | Define an empty 'default' element for the SVG tree.
 -- It is used as base when parsing the element from XML.


### PR DESCRIPTION
(This is a mess, but I figured I'd see what you think before I go any further...)

Currently serialisation is hardcoded to always use six decimal places, which is often excessive. For my use case, it would be really great to get this down.

Unfortunately this change is very pervasive. And this is probably only about half of it (see `hardcodedPrecision`). I feel I ought to take a step back and try to understand the library architecture better to see if there may be a more elegant solution. Perhaps some refactoring is in order first - for example things like `ParseableAttribute` and `parseIn` have clearly outgrown their original purpose (not a criticism of you - I see that code predates the fork).