### PR TITLE
Fix "simplifier ticks exhausted" error

### DIFF
--- a/reanimate-svg.cabal
+++ b/reanimate-svg.cabal
@@ -28,7 +28,7 @@ Source-Repository head
 
 library
   hs-source-dirs: src
-  ghc-options: -Wall
+  ghc-options: -Wall -fsimpl-tick-factor=300
   default-language: Haskell2010
   exposed-modules: Graphics.SvgTree
                  , Graphics.SvgTree.CssTypes


### PR DESCRIPTION
This commit addresses a common error when compiling with GHC 9 by increasing the simplifier tick factor from 100 (default) to 300.

Relevant issues: #41, reanimate #311