### PR TITLE
Bump patch version number

### DIFF
--- a/reanimate-svg.cabal
+++ b/reanimate-svg.cabal
@@ -1,6 +1,6 @@
 cabal-version:       2.2
 name:                reanimate-svg
-version:             0.13.0.1
+version:             0.13.0.2
 synopsis:            SVG file loader and serializer
 description:
   `reanimate-svg` provides types representing a SVG document,


### PR DESCRIPTION
This commit increments the version number to 0.13.0.2 to include the "simplifier ticks exhausted" fix.