### PR TITLE
Fix to build with GHC 9.6

### DIFF
--- a/reanimate-svg.cabal
+++ b/reanimate-svg.cabal
@@ -59,8 +59,8 @@ library
                , linear            >= 1.20
                , vector            >= 0.10
                , text              >= 1.1
-               , transformers      >= 0.3 && < 0.6
-               , mtl               >= 2.1 && < 2.3
+               , transformers      >= 0.3 && < 0.7
+               , mtl               >= 2.1 && < 2.4
                , lens              >= 4.6 && < 6
                , double-conversion >= 2.0.0.0 && < 3.0.0.0
                , hashable          >= 1.3.0.0

--- a/reanimate-svg.cabal
+++ b/reanimate-svg.cabal
@@ -28,7 +28,7 @@ Source-Repository head
 
 library
   hs-source-dirs: src
-  ghc-options: -Wall -fsimpl-tick-factor=300
+  ghc-options: -Wall -fsimpl-tick-factor=1000
   default-language: Haskell2010
   exposed-modules: Graphics.SvgTree
                  , Graphics.SvgTree.CssTypes


### PR DESCRIPTION
For context on the tick-factor issue, see #41 and #43. The other commit essentially cherry-picks https://github.com/Twinside/svg-tree/pull/29.